### PR TITLE
Opción de descuento por el uso del pago y fix de un pequeño bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 /*Archivos a ignorar */
 *.php
+*.rar
 
 /*Directorios a seguir */
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/*Directorio a ignorar */
+
+*/
+
+/*Archivos a ignorar */
+*.php
+
+/*Directorios a seguir */
+
+!wp-content/plugins/tropipay/
+

--- a/tropipay/class-wc-tropipay.php
+++ b/tropipay/class-wc-tropipay.php
@@ -22,8 +22,6 @@
  * Tropipay
  */
 
-use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
-use Yoast\WP\Lib\Migrations\Constants;
 
 /**
  * Plugin Name: Tropipay WooCommerce

--- a/tropipay/class-wc-tropipay.php
+++ b/tropipay/class-wc-tropipay.php
@@ -1,26 +1,26 @@
 <?php
 
 /**
-* NOTA SOBRE LA LICENCIA DE USO DEL SOFTWARE
-* 
-* El uso de este software está sujeto a las Condiciones de uso de software que
-* se incluyen en el paquete en el documento "Aviso Legal.pdf". También puede
-* obtener una copia en la siguiente url:
-* https://www.tropipay.com/terms
-* 
-* Tropipay es titular de todos los derechos de propiedad intelectual e industrial
-* del software.
-* 
-* Quedan expresamente prohibidas la reproducción, la distribución y la
-* comunicación pública, incluida su modalidad de puesta a disposición con fines
-* distintos a los descritos en las Condiciones de uso.
-* 
-* Tropipay se reserva la posibilidad de ejercer las acciones legales que le
-* correspondan para hacer valer sus derechos frente a cualquier infracción de
-* los derechos de propiedad intelectual y/o industrial.
-* 
-* Tropipay
-*/
+ * NOTA SOBRE LA LICENCIA DE USO DEL SOFTWARE
+ * 
+ * El uso de este software está sujeto a las Condiciones de uso de software que
+ * se incluyen en el paquete en el documento "Aviso Legal.pdf". También puede
+ * obtener una copia en la siguiente url:
+ * https://www.tropipay.com/terms
+ * 
+ * Tropipay es titular de todos los derechos de propiedad intelectual e industrial
+ * del software.
+ * 
+ * Quedan expresamente prohibidas la reproducción, la distribución y la
+ * comunicación pública, incluida su modalidad de puesta a disposición con fines
+ * distintos a los descritos en las Condiciones de uso.
+ * 
+ * Tropipay se reserva la posibilidad de ejercer las acciones legales que le
+ * correspondan para hacer valer sus derechos frente a cualquier infracción de
+ * los derechos de propiedad intelectual y/o industrial.
+ * 
+ * Tropipay
+ */
 
 /**
  * Plugin Name: Tropipay WooCommerce
@@ -31,91 +31,123 @@
  *
  */
 
-define( 'WC_TROPIPAY_MAIN_FILE', __FILE__ );
-add_action( 'init', 'init_tropipay' );
-add_action( 'plugins_loaded', 'load_tropipay' );
+define('WC_TROPIPAY_MAIN_FILE', __FILE__);
+add_action('init', 'init_tropipay');
+add_action('plugins_loaded', 'load_tropipay');
 
-function init_tropipay() {
-    load_plugin_textdomain( "tropipay", false, dirname( plugin_basename( __FILE__ ) ));
+function init_tropipay()
+{
+  load_plugin_textdomain("tropipay", false, dirname(plugin_basename(__FILE__)));
 }
 
-function load_tropipay() {
-    if ( !class_exists( 'WC_Payment_Gateway' ) ) 
-        exit;
+function load_tropipay()
+{
+  if (!class_exists('WC_Payment_Gateway'))
+    exit;
 
-    include_once ('wc-tropipay.php');
-    require_once plugin_dir_path( __FILE__ ) . 'includes/tropipay-checkout-description-fields.php';
-	
-    add_filter( 'woocommerce_payment_gateways', 'anadir_pago_woocommerce_tropipay' );
+  include_once('wc-tropipay.php');
+  require_once plugin_dir_path(__FILE__) . 'includes/tropipay-checkout-description-fields.php';
+
+  add_filter('woocommerce_payment_gateways', 'anadir_pago_woocommerce_tropipay');
 }
 
-function anadir_pago_woocommerce_tropipay($methods) {
-    $methods[] = 'WC_Tropipay';
-    return $methods;
+function anadir_pago_woocommerce_tropipay($methods)
+{
+  $methods[] = 'WC_Tropipay';
+  return $methods;
 }
 
 /**
  * Add a fee when the user checks out with PayPal
  */
-function tropipay_apply_payment_gateway_fee($cart) {
+function tropipay_apply_payment_gateway_fee($cart)
+{
   $totals = $cart->get_totals();
   $calculateamount = $totals["cart_contents_total"] + $totals["cart_contents_tax"];
-  $payment_method = WC()->session->get( 'chosen_payment_method' );
+  $payment_method = WC()->session->get('chosen_payment_method');
 
-  if ( ! empty( $_POST['post_data'] ) ) {
-    setcookie( 'customer-post-data', sanitize_text_field( $_POST['post_data'] ), 0 );
+  if (!empty($_POST['post_data'])) {
+    setcookie('customer-post-data', sanitize_text_field($_POST['post_data']), 0);
   }
 
-  $posted_data = sanitize_text_field( $_POST['post_data'] ?? '' );
+  $posted_data = sanitize_text_field($_POST['post_data'] ?? '');
 
   // in case of absence of $_POST['post_data'] - take it from cookie
-  if ( empty( $posted_data ) && ! empty( $_COOKIE['customer-post-data'] ) ) {
+  if (empty($posted_data) && !empty($_COOKIE['customer-post-data'])) {
     $posted_data = $_COOKIE['customer-post-data'];
   }
   // Only apply the fee if the payment gateway is PayPal
   // Note that you might need to check this slug, depending on the PayPal gateway you're using
   parse_str($posted_data, $post_data_array);
   $payment_method = $post_data_array['payment_method'];
-  if( $payment_method == 'tropipay' && $posted_data) {
+  if ($payment_method == 'tropipay' && $posted_data) {
     $metodo_pago = new WC_Tropipay;
     // parse_str($posted_data, $post_data_array);
     $tropipay_payment_method = $post_data_array['tropipay_payment_method'];
-    if($metodo_pago->tropipayaddFees==='si') {
-      if($tropipay_payment_method === 'card' || $_POST["tropipay_payment_method"] === 'card') {
-          /*$label = __( 'Comisión pago', 'tropipay-woo' );*/
-          $amount = round(floatval($calculateamount / floatval(1 - (floatval($metodo_pago->tropipayfeecardpercent)/100))), 2) + floatval($metodo_pago->tropipayfeecardfixed) - $calculateamount;
-          WC()->cart->add_fee( $label, $amount, true, 'standard' );
+    if ($metodo_pago->tropipayaddFees === 'si') {
+      if ($tropipay_payment_method === 'card' || $_POST["tropipay_payment_method"] === 'card') {
+        /*$label = __( 'Comisión pago', 'tropipay-woo' );*/
+        $amount = round(floatval($calculateamount / floatval(1 - (floatval($metodo_pago->tropipayfeecardpercent) / 100))), 2) + floatval($metodo_pago->tropipayfeecardfixed) - $calculateamount;
+        WC()->cart->add_fee($label, $amount, true, 'standard');
       }
-      if($tropipay_payment_method === 'balance'  || $_POST["tropipay_payment_method"] === 'balance') {
-          $label = __( 'Comisión pago', 'tropipay-woo' );
-          $amount = floatval($calculateamount / floatval(1 - (floatval($metodo_pago->tropipayfeebalancepercent)/100))) + floatval($metodo_pago->tropipayfeebalancefixed) - $calculateamount;
-          WC()->cart->add_fee( $label, $amount, true, 'standard' );
+      if ($tropipay_payment_method === 'balance'  || $_POST["tropipay_payment_method"] === 'balance') {
+        $label = __('Comisión pago', 'tropipay-woo');
+        $amount = floatval($calculateamount / floatval(1 - (floatval($metodo_pago->tropipayfeebalancepercent) / 100))) + floatval($metodo_pago->tropipayfeebalancefixed) - $calculateamount;
+        WC()->cart->add_fee($label, $amount, true, 'standard');
       }
     }
   }
 }
 
-add_action( 'woocommerce_cart_calculate_fees', 'tropipay_apply_payment_gateway_fee');
+add_action('woocommerce_cart_calculate_fees', 'tropipay_apply_payment_gateway_fee');
 
 
 /**
  * Add some JS
  */
-function tropipay_script() {
-    ?>
-    <script>
-    jQuery(document).ready(function($){
-      $('body').on('click','.checkout #tropipay_payment_method_card',function(){
+function tropipay_script()
+{
+?>
+  <script>
+    jQuery(document).ready(function($) {
+      $('body').on('click', '.checkout #tropipay_payment_method_card', function() {
         $('body').trigger('update_checkout');
       });
-      $('body').on('click','.checkout #tropipay_payment_method_balance',function(){
+      $('body').on('click', '.checkout #tropipay_payment_method_balance', function() {
         $('body').trigger('update_checkout');
       });
-             
-    });
 
-    </script>
-  <?php
+    });
+  </script>
+<?php
 }
 
-add_action( 'woocommerce_after_checkout_form', 'tropipay_script' );
+add_action('woocommerce_after_checkout_form', 'tropipay_script');
+
+function add_attribs_script($hook)
+{
+  if ($hook != 'woocommerce_page_wc-settings')
+    return;
+
+?>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+
+      var txtrequire = document.getElementsByClassName("tropipayinput");
+      Array.prototype.forEach.call(txtrequire, function(txt) {
+        txt.setAttribute("required", "");
+        txt.addEventListener("input", () => {
+          if (!/^\d*$/.test(txt.value)) {
+            txt.value = txt.value.substring(0, txt.value.length - 1);
+          }
+
+        });
+      });
+
+    });
+  </script>
+<?php
+  echo "function ready";
+}
+//Engancho el script solo en la pagina de administracion
+add_action('admin_enqueue_scripts', 'add_attribs_script');

--- a/tropipay/class-wc-tropipay.php
+++ b/tropipay/class-wc-tropipay.php
@@ -86,7 +86,7 @@ function tropipay_apply_payment_gateway_fee($cart)
     $tropipay_payment_method = $post_data_array['tropipay_payment_method'];
     if ($metodo_pago->tropipayaddFees === 'si') {
       if ($tropipay_payment_method === 'card' || $_POST["tropipay_payment_method"] === 'card') {
-        /*$label = __( 'Comisión pago', 'tropipay-woo' );*/
+        $label = __('Comisión pago', 'tropipay-woo');
         $amount = round(floatval($calculateamount / floatval(1 - (floatval($metodo_pago->tropipayfeecardpercent) / 100))), 2) + floatval($metodo_pago->tropipayfeecardfixed) - $calculateamount;
         WC()->cart->add_fee($label, $amount, true, 'standard');
       }
@@ -110,19 +110,33 @@ function tropipay_script()
 ?>
   <script>
     jQuery(document).ready(function($) {
+
       $('body').on('click', '.checkout #tropipay_payment_method_card', function() {
         $('body').trigger('update_checkout');
       });
+
       $('body').on('click', '.checkout #tropipay_payment_method_balance', function() {
         $('body').trigger('update_checkout');
       });
 
+
+      //Check if after the user select tropipay method, changes his/her choice
+      $(document.body).on('change', 'input[name="payment_method"]', function() {
+        if ($(this).val() !== 'tropipay') {
+          $('body').trigger('update_checkout');
+        }
+
+      });
     });
   </script>
 <?php
 }
 
 add_action('woocommerce_after_checkout_form', 'tropipay_script');
+
+
+
+
 
 function add_attribs_script($hook)
 {
@@ -147,7 +161,6 @@ function add_attribs_script($hook)
     });
   </script>
 <?php
-  echo "function ready";
 }
 //Engancho el script solo en la pagina de administracion
 add_action('admin_enqueue_scripts', 'add_attribs_script');

--- a/tropipay/class-wc-tropipay.php
+++ b/tropipay/class-wc-tropipay.php
@@ -22,6 +22,7 @@
  * Tropipay
  */
 
+use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Yoast\WP\Lib\Migrations\Constants;
 
 /**
@@ -36,6 +37,7 @@ use Yoast\WP\Lib\Migrations\Constants;
 define('WC_TROPIPAY_MAIN_FILE', __FILE__);
 add_action('init', 'init_tropipay');
 add_action('plugins_loaded', 'load_tropipay');
+add_action('woocommerce_review_order_before_cart_contents', 'update_totals');
 
 function init_tropipay()
 {
@@ -65,6 +67,7 @@ function anadir_pago_woocommerce_tropipay($methods)
 function tropipay_apply_payment_gateway_fee($cart)
 {
   $totals = $cart->get_totals();
+  
 
   $calculateamount = $totals["cart_contents_total"] + $totals["cart_contents_tax"];
   $payment_method = WC()->session->get('chosen_payment_method');
@@ -108,6 +111,7 @@ function tropipay_apply_payment_gateway_fee($cart)
     }
     else if($options['tropipaydiscountpercent'] == 'no' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'percent_ofer') == 1){
       WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'percent_ofer');
+ 
     }
 
     if ($options['tropipaydiscountamount'] == 'yes' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'fixed_ofer') != 1) {
@@ -115,19 +119,30 @@ function tropipay_apply_payment_gateway_fee($cart)
     }
     else if( $options['tropipaydiscountamount'] == 'no' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'fixed_ofer') == 1 ){
       WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'fixed_ofer');
+     
     }
 
     
   }
    else if ($payment_method != 'tropipay') {
-
     if (WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'percent_ofer') == 1) {
       WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'percent_ofer');
+      
     }
     if (WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'fixed_ofer') == 1) {
       WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'fixed_ofer');
+
     }
   }
+
+}
+
+
+
+function update_totals() {
+    // Recalcula los totales del carrito
+    WC()->cart->calculate_totals();
+    
 }
 
 add_action('woocommerce_cart_calculate_fees', 'tropipay_apply_payment_gateway_fee');

--- a/tropipay/class-wc-tropipay.php
+++ b/tropipay/class-wc-tropipay.php
@@ -102,14 +102,25 @@ function tropipay_apply_payment_gateway_fee($cart)
         WC()->cart->add_fee($label, $amount, true, 'standard');
       }
     }
-    //echo WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'percent_ofer');
+    
     if ($options['tropipaydiscountpercent'] == 'yes' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'percent_ofer') != 1) {
       WC()->cart->apply_coupon($options['tropipaydiscountcouponcaption'] . 'percent_ofer');
     }
+    else if($options['tropipaydiscountpercent'] == 'no' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'percent_ofer') == 1){
+      WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'percent_ofer');
+    }
+
     if ($options['tropipaydiscountamount'] == 'yes' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'fixed_ofer') != 1) {
       WC()->cart->apply_coupon($options['tropipaydiscountcouponcaption'] . 'fixed_ofer');
     }
-  } else if ($payment_method == 'tropipay') {
+    else if( $options['tropipaydiscountamount'] == 'no' && WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'fixed_ofer') == 1 ){
+      WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'fixed_ofer');
+    }
+
+    
+  }
+   else if ($payment_method != 'tropipay') {
+
     if (WC()->cart->has_discount($options['tropipaydiscountcouponcaption'] . 'percent_ofer') == 1) {
       WC()->cart->remove_coupon($options['tropipaydiscountcouponcaption'] . 'percent_ofer');
     }

--- a/tropipay/class-wc-tropipay.php
+++ b/tropipay/class-wc-tropipay.php
@@ -82,7 +82,7 @@ function tropipay_apply_payment_gateway_fee($cart) {
     $tropipay_payment_method = $post_data_array['tropipay_payment_method'];
     if($metodo_pago->tropipayaddFees==='si') {
       if($tropipay_payment_method === 'card' || $_POST["tropipay_payment_method"] === 'card') {
-          $label = __( 'Comisión pago', 'tropipay-woo' );
+          /*$label = __( 'Comisión pago', 'tropipay-woo' );*/
           $amount = round(floatval($calculateamount / floatval(1 - (floatval($metodo_pago->tropipayfeecardpercent)/100))), 2) + floatval($metodo_pago->tropipayfeecardfixed) - $calculateamount;
           WC()->cart->add_fee( $label, $amount, true, 'standard' );
       }
@@ -110,7 +110,8 @@ function tropipay_script() {
       });
       $('body').on('click','.checkout #tropipay_payment_method_balance',function(){
         $('body').trigger('update_checkout');
-      });        
+      });
+             
     });
 
     </script>

--- a/tropipay/includes/tropipay-checkout-description-fields.php
+++ b/tropipay/includes/tropipay-checkout-description-fields.php
@@ -52,7 +52,9 @@ function tropipay_checkout_form_get_field_values()
 
 function tropipay_description_fields_validation()
 {
+
     $field_values = tropipay_checkout_form_get_field_values();
+    var_dump($field_values);
     if (empty($field_values['tropipay_payment_method']) && $field_values['payment_method'] === 'tropipay') {
         wc_add_notice('Por favor seleccione la forma de pago con TropiPay', 'error');
     }
@@ -61,10 +63,6 @@ function tropipay_description_fields_validation()
 function tropipay_description_fields($description, $payment_id)
 {
     global $woocommerce;
-
-    /*echo '<p style="background-color:yellow;"> ';
-    var_dump($woocommerce->cart);
-    echo '</p>';*/
 
     if ('tropipay' !== $payment_id) {
         return $description;

--- a/tropipay/includes/tropipay-checkout-description-fields.php
+++ b/tropipay/includes/tropipay-checkout-description-fields.php
@@ -9,6 +9,8 @@ add_action('woocommerce_checkout_process', 'tropipay_description_fields_validati
 add_action('woocommerce_checkout_update_order_meta', 'tropipay_checkout_update_order_meta', 1, 1);
 #add_action( 'woocommerce_order_item_meta_end', 'tropipay_order_item_meta_end', 10, 3 );
 
+
+/// Verificamos si estan activados los descuentos y se le notifica al usuario para insentivar su uso
 function tropipay_change_name_gateway($title, $id_gateway)
 {
 
@@ -88,14 +90,14 @@ function tropipay_description_fields($description, $payment_id)
     }
 
     if ($metodo_pago->settings['tropipaydiscountpercent'] == 'yes') {
-        echo '<br>Se le aplicará un ' . $metodo_pago->settings['tropipaydiscountpercentcuantity'] . '% de <b>Descuento</b> a su cuenta final';
+        echo '<p>Se le aplicará un ' . $metodo_pago->settings['tropipaydiscountpercentcuantity'] . '% de <b>Descuento</b> a su cuenta final</p>';
     }
     if ($metodo_pago->settings['tropipaydiscountamount'] == 'yes') {
-        echo '<br>Se le aplicara un <b>Descuento</b> fijo de ' . $metodo_pago->settings['tropipaydiscountamountcuantity'];
+        echo '<p>Se le aplicara un <b>Descuento</b> fijo de ' . $metodo_pago->settings['tropipaydiscountamountcuantity'];
         if ($metodo_pago->settings['tropipaymoneda'] == 'AUTO')
-            echo ' USD';
+            echo ' USD</p>';
         else
-            echo ' ' . $metodo_pago->settings['tropipaymoneda'];
+            echo ' ' . $metodo_pago->settings['tropipaymoneda'].'</p>';
     }
 
 

--- a/tropipay/includes/tropipay-checkout-description-fields.php
+++ b/tropipay/includes/tropipay-checkout-description-fields.php
@@ -1,7 +1,5 @@
 <?php
 
-use Elementor\Settings;
-
 add_filter('woocommerce_gateway_description', 'tropipay_description_fields', 20, 2);
 add_filter('woocommerce_gateway_title', 'tropipay_change_name_gateway', 10, 2);
 
@@ -64,6 +62,10 @@ function tropipay_description_fields($description, $payment_id)
 {
     global $woocommerce;
 
+    /*echo '<p style="background-color:yellow;"> ';
+    var_dump($woocommerce->cart);
+    echo '</p>';*/
+
     if ('tropipay' !== $payment_id) {
         return $description;
     }
@@ -97,7 +99,7 @@ function tropipay_description_fields($description, $payment_id)
         if ($metodo_pago->settings['tropipaymoneda'] == 'AUTO')
             echo ' USD</p>';
         else
-            echo ' ' . $metodo_pago->settings['tropipaymoneda'].'</p>';
+            echo ' ' . $metodo_pago->settings['tropipaymoneda'] . '</p>';
     }
 
 

--- a/tropipay/includes/tropipay-checkout-description-fields.php
+++ b/tropipay/includes/tropipay-checkout-description-fields.php
@@ -1,89 +1,125 @@
 <?php
 
-add_filter( 'woocommerce_gateway_description', 'tropipay_description_fields', 20, 2 );
-add_action( 'woocommerce_checkout_process', 'tropipay_description_fields_validation' );
-add_action( 'woocommerce_checkout_update_order_meta', 'tropipay_checkout_update_order_meta', 1, 1 );
+use Elementor\Settings;
+
+add_filter('woocommerce_gateway_description', 'tropipay_description_fields', 20, 2);
+add_filter('woocommerce_gateway_title', 'tropipay_change_name_gateway', 10, 2);
+
+add_action('woocommerce_checkout_process', 'tropipay_description_fields_validation');
+add_action('woocommerce_checkout_update_order_meta', 'tropipay_checkout_update_order_meta', 1, 1);
 #add_action( 'woocommerce_order_item_meta_end', 'tropipay_order_item_meta_end', 10, 3 );
 
-function tropipay_checkout_update_order_meta($order_id) {
-    delete_post_meta( $order_id, 'tropipay_payment_receipt' );
-    if ( ! empty( $_POST['tropipay_payment_method'] ) ) {
-        delete_post_meta( $order_id, 'tropipay_payment_method' );
-        add_post_meta( $order_id, 'tropipay_payment_method', sanitize_text_field( $_POST['tropipay_payment_method'] ) );
+function tropipay_change_name_gateway($title, $id_gateway)
+{
+
+    $metodo_pago = new WC_Tropipay;
+
+    if ($id_gateway == $metodo_pago->id && ($metodo_pago->settings['tropipaydiscountpercent'] == 'yes' ||
+        $metodo_pago->settings['tropipaydiscountamount'] == 'yes')) {
+
+        $title .= ' <span class="tropipay_oferta"><b>"Descuento"</b></span>';
+    }
+
+    return $title;
+}
+
+function tropipay_checkout_update_order_meta($order_id)
+{
+    delete_post_meta($order_id, 'tropipay_payment_receipt');
+    if (!empty($_POST['tropipay_payment_method'])) {
+        delete_post_meta($order_id, 'tropipay_payment_method');
+        add_post_meta($order_id, 'tropipay_payment_method', sanitize_text_field($_POST['tropipay_payment_method']));
     }
 }
 
-function tropipay_checkout_form_get_field_values() {
+function tropipay_checkout_form_get_field_values()
+{
     $fields = [
         'tropipay_payment_method' => '',
         'payment_method' => ''
     ];
 
-    foreach( $fields as $field_name => $value ) {
-        if( !empty( $_POST[ $field_name ] ) ) {
-            $fields[ $field_name ] = sanitize_text_field( $_POST[ $field_name ] );
+    foreach ($fields as $field_name => $value) {
+        if (!empty($_POST[$field_name])) {
+            $fields[$field_name] = sanitize_text_field($_POST[$field_name]);
         } else {
-            unset( $fields[ $field_name ] );
+            unset($fields[$field_name]);
         }
     }
 
     return $fields;
 }
 
-function tropipay_description_fields_validation() {
+function tropipay_description_fields_validation()
+{
     $field_values = tropipay_checkout_form_get_field_values();
-    if ( empty( $field_values['tropipay_payment_method'] ) && $field_values['payment_method'] === 'tropipay' ) {
-        wc_add_notice( 'Por favor seleccione la forma de pago con TropiPay', 'error' );
+    if (empty($field_values['tropipay_payment_method']) && $field_values['payment_method'] === 'tropipay') {
+        wc_add_notice('Por favor seleccione la forma de pago con TropiPay', 'error');
     }
 }
 
-function tropipay_description_fields( $description, $payment_id ) {
+function tropipay_description_fields($description, $payment_id)
+{
     global $woocommerce;
 
-    if ( 'tropipay' !== $payment_id ) {
+    if ('tropipay' !== $payment_id) {
         return $description;
     }
-    
+
     $metodo_pago = new WC_Tropipay;
 
     ob_start();
 
     $tropipaymentmethods = $metodo_pago->get_option('tropipaymentmethods');
 
-    if($metodo_pago->tropipayaddFees==='si' && $metodo_pago->tropipayshowfees==='si') {
-        if(floatval($metodo_pago->tropipayfeecardpercent)>0) {
-            $labelcardextrafee= ' ' . $metodo_pago->tropipayfeecardpercent . '%';
+    if ($metodo_pago->tropipayaddFees === 'si' && $metodo_pago->tropipayshowfees === 'si') {
+        if (floatval($metodo_pago->tropipayfeecardpercent) > 0) {
+            $labelcardextrafee = ' ' . $metodo_pago->tropipayfeecardpercent . '%';
         }
-        if(floatval($metodo_pago->tropipayfeecardfixed)>0) {
-            $labelcardextrafee.= ' +' . $metodo_pago->tropipayfeecardfixed;
+        if (floatval($metodo_pago->tropipayfeecardfixed) > 0) {
+            $labelcardextrafee .= ' +' . $metodo_pago->tropipayfeecardfixed;
         }
-        if(floatval($metodo_pago->tropipayfeebalancepercent)>0) {
-            $labelbalanceextrafee= ' ' . $metodo_pago->tropipayfeebalancepercent . '%';
+        if (floatval($metodo_pago->tropipayfeebalancepercent) > 0) {
+            $labelbalanceextrafee = ' ' . $metodo_pago->tropipayfeebalancepercent . '%';
         }
-        if(floatval($metodo_pago->tropipayfeebalancefixed)>0) {
-            $labelbalanceextrafee.= ' +' . $metodo_pago->tropipayfeebalancefixed;
+        if (floatval($metodo_pago->tropipayfeebalancefixed) > 0) {
+            $labelbalanceextrafee .= ' +' . $metodo_pago->tropipayfeebalancefixed;
         }
     }
+
+    if ($metodo_pago->settings['tropipaydiscountpercent'] == 'yes') {
+        echo '<br>Se le aplicará un ' . $metodo_pago->settings['tropipaydiscountpercentcuantity'] . '% de <b>Descuento</b> a su cuenta final';
+    }
+    if ($metodo_pago->settings['tropipaydiscountamount'] == 'yes') {
+        echo '<br>Se le aplicara un <b>Descuento</b> fijo de ' . $metodo_pago->settings['tropipaydiscountamountcuantity'];
+        if ($metodo_pago->settings['tropipaymoneda'] == 'AUTO')
+            echo ' USD';
+        else
+            echo ' ' . $metodo_pago->settings['tropipaymoneda'];
+    }
+
+
+
 
     $default = '';
 
     $optionst = array(
-        'card' => __( 'Tarjeta de crédito', 'tropipay-woo' ) . $labelcardextrafee,
-        'balance' => __( 'Saldo de Tropipay', 'tropipay-woo' ) . $labelbalanceextrafee,
+        'card' => __('Tarjeta de crédito', 'tropipay-woo') . $labelcardextrafee,
+        'balance' => __('Saldo de Tropipay', 'tropipay-woo') . $labelbalanceextrafee,
     );
 
-    if($tropipaymentmethods === 'onlycard') {
+    if ($tropipaymentmethods === 'onlycard') {
         unset($optionst['balance']);
         $default = 'card';
     }
-    if($tropipaymentmethods === 'onlytpp') {
+    if ($tropipaymentmethods === 'onlytpp') {
         unset($optionst['card']);
         $default = 'balance';
     }
 
     $element = array(
         'type' => 'radio',
-        'class' => array( 'form-row', 'form-row-wide' ),
+        'class' => array('form-row', 'form-row-wide'),
         'required' => true,
         'options' => $optionst,
         'default' => $default,
@@ -96,7 +132,6 @@ function tropipay_description_fields( $description, $payment_id ) {
 
     if ($metodo_pago->get_option('tropipayshowlogo') === 'si')
         echo '<div class="logoTropipay"></div>';
-
 
     $description .= ob_get_clean();
 

--- a/tropipay/pages/assets/css/tropipay.css
+++ b/tropipay/pages/assets/css/tropipay.css
@@ -9,3 +9,7 @@
     background: url(../images/logoTropiPay.png) no-repeat left;
     background-size: contain;
 }
+
+.tropipay_oferta{
+    background-color: rgb(131, 233, 100);
+}

--- a/tropipay/wc-tropipay.php
+++ b/tropipay/wc-tropipay.php
@@ -66,10 +66,46 @@ class WC_Tropipay extends WC_Payment_Gateway
         // Actions
         add_action('woocommerce_receipt_tropipay', array($this, 'receipt_page_tropipay'));
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
+        add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'tropipay_coupons_check'));
         //Payment listener/API hook
         add_action('woocommerce_api_wc_tropipay', array($this, 'check_rds_response'));
         add_action('wp_enqueue_scripts', [$this, 'payment_scripts']);
     }
+
+    function tropipay_coupons_check()
+    {
+
+        $options = get_option('woocommerce_tropipay_settings');
+
+        if ($options['tropipaydiscountpercent'] == 'yes') {
+
+            $coupon_id = $options['tropipaydiscountcouponcaption'] . 'percent_ofer';
+            $discount_type = 'percent';
+
+            //Create discoun percent coupon
+            $coupon_percent = new WC_Coupon();
+            $coupon_percent->set_code($coupon_id);
+            $coupon_percent->set_discount_type($discount_type);
+            $coupon_percent->set_amount(intval($options['tropipaydiscountpercentcuantity']));
+            $coupon_percent->set_individual_use(false);
+            $coupon_percent->save();
+        }
+
+        if ($options['tropipaydiscountamount'] == 'yes') {
+
+            $coupon_id = $options['tropipaydiscountcouponcaption'] . 'fixed_ofer';
+            $discount_type = 'fixed_cart';
+
+            //Create discoun fixed coupon
+            $coupon_fixed = new WC_Coupon();
+            $coupon_fixed->set_code($coupon_id);
+            $coupon_fixed->set_discount_type($discount_type);
+            $coupon_fixed->set_amount(intval($options['tropipaydiscountamountcuantity']));
+            $coupon_fixed->set_individual_use(false);
+            $coupon_fixed->save();
+        }
+    }
+
 
     function generateIdLog()
     {
@@ -87,23 +123,6 @@ class WC_Tropipay extends WC_Payment_Gateway
         wp_register_style('tropipay_styles', plugins_url('pages/assets/css/tropipay.css', WC_TROPIPAY_MAIN_FILE));
         wp_enqueue_style('tropipay_styles');
     }
-
-    /*function payment_fields() {
-        global $woocommerce;
-        //echo '<label for="mi_metodo_pago_tipo_pago">Seleccione el tipo de pago:</label>';
-        echo '<div>';
-        echo '<input type="radio" id="mi_metodo_pago_tipo_pago_tarjeta" name="mi_metodo_pago_tipo_pago" value="tarjeta" required>';
-        echo '<label for="mi_metodo_pago_tipo_pago_tarjeta">Tarjeta de crédito</label>';
-        echo '</div>';
-        echo '<div>';
-        echo '<input type="radio" id="mi_metodo_pago_tipo_pago_balance" name="mi_metodo_pago_tipo_pago" value="balance" required>';
-        echo '<label for="mi_metodo_pago_tipo_pago_balance">Pagar con balance de TropiPay</label>';
-        echo '</div>';
-    }*/
-
-    //Agregando los atributos requiere  a las opciones que asi lo necesitan
-    //y validaciones en la entrada
-    //Esto tengo que pasarlo despues para un doc aparte con todo el javascript
 
 
     function init_form_fields()
@@ -307,7 +326,7 @@ class WC_Tropipay extends WC_Payment_Gateway
             'tropipaydiscountpercentcuantity' => array(
                 'title' => __('Valor del porciento de descuento', 'woocommerce'),
                 'type'  => 'text',
-                'description' => __('Valor del pociento de descueto que se desea aplicar a la cuenta del cliente. <br> Este porciento será aplicado al monto final de la cuenta del cliente.'),
+                'description' => __('Valor del pociento de descueto que se desea aplicar a la cuenta del cliente. <br> Este porciento será aplicado al monto final de la cuenta del cliente.', 'woocommerce'),
                 'default' => 0,
                 'desc_tip' => true,
                 'class' =>  "tropipayinput",
@@ -328,7 +347,14 @@ class WC_Tropipay extends WC_Payment_Gateway
                 'default' => 0,
                 'desc_tip' => true,
                 'class' =>  "tropipayinput",
-            )
+            ),
+            'tropipaydiscountcouponcaption' => array(
+                'title' => __('Nombre para los cupones descuento', 'woocommerce'),
+                'type'  => 'text',
+                'description' => __('Nombre personalizado para el/los cupon/es de descuentos que seran aplicados por el metodo de pago de Tropipay', 'woocommerce'),
+                'default' => 'Tropipay',
+                'desc_tip' => true,
+            ),
         );
 
 

--- a/tropipay/wc-tropipay.php
+++ b/tropipay/wc-tropipay.php
@@ -102,10 +102,10 @@ class WC_Tropipay extends WC_Payment_Gateway {
       //Agregando los atributos requiere  a las opciones que asi lo necesitan
       //y validaciones en la entrada
       //Esto tengo que pasarlo despues para un doc aparte con todo el javascript
-      function add_attribs_script() {
+    function add_attribs_script() {
         ?>
         <script>
-            document.addEventListener("DOMContentLoaded",function(){
+            /*document.addEventListener("DOMContentLoaded",function(){
 
                 var txtrequire=document.getElementsByClassName("tropipayinput");
                     Array.prototype.forEach.call(txtrequire, function(txt) {
@@ -115,10 +115,10 @@ class WC_Tropipay extends WC_Payment_Gateway {
                                 txt.value=txt.value.substring(0,txt.value.length-1);
                             }
                                                     
-                         })
+                         });
                 });               
                                             
-            });
+            });*/
     
         </script>
       <?php
@@ -349,7 +349,7 @@ class WC_Tropipay extends WC_Payment_Gateway {
 			   	);
 
                 //Agregando los atributos a los campos requieridos
-                $this->add_attribs_script();
+                //$this->add_attribs_script();
                 
 				
 				$tmp_estados=wc_get_order_statuses();
@@ -357,12 +357,8 @@ class WC_Tropipay extends WC_Payment_Gateway {
                	foreach($tmp_estados as $est_id=>$est_na){
                     $this->form_fields['tropipayestado']['options'][substr($est_id,3)]=$est_na;
 				}
-    }
-
-  
-
-   
-
+    
+            }
     function process_payment( $order_id ) {
         global $woocommerce;
         $order = new WC_Order($order_id);
@@ -429,7 +425,8 @@ class WC_Tropipay extends WC_Payment_Gateway {
         $arraycliente["address"]=$order->get_billing_address_1() . ", " . $order->get_billing_city() . ", " . $order->get_billing_postcode();
         if($order->get_billing_phone()) {
             $arraycliente["phone"]=$order->get_billing_phone();
-        } else {
+        }
+         else {
             $arraycliente["phone"]=$order->get_shipping_phone();
         }
         $arraycliente["email"]=$order->get_billing_email();
@@ -473,6 +470,7 @@ class WC_Tropipay extends WC_Payment_Gateway {
                 break;
         }
         $paylink = $srv->createPaylink($datos);
+        //var_dump($datos);
         $shorturl=$paylink['data']['shortUrl'];
         
         $paymenturl=$paylink['data']['paymentUrl'];
@@ -596,8 +594,9 @@ class WC_Tropipay extends WC_Payment_Gateway {
             $this->log->add( 'tropipay', $texto."\r\n");
         }
     }
-}
+
 
     function tropipay_get_bankordercode($order_id) {
         return get_post_meta( $order_id, 'bankOrderCode', true );
     }
+}

--- a/tropipay/wc-tropipay.php
+++ b/tropipay/wc-tropipay.php
@@ -43,7 +43,7 @@ class WC_Tropipay extends WC_Payment_Gateway {
 
         $this->title              = $this->get_option( 'title' );
         $this->description        = $this->get_option( 'description' );
-
+        
         // Get settings
         $this->tropipayentorno            = $this->get_option( 'tropipayentorno' );
         $this->tropipaymail             = $this->get_option( 'tropipaymail' );
@@ -285,7 +285,42 @@ class WC_Tropipay extends WC_Payment_Gateway {
                         'no' => __( 'No', 'woocommerce' ),
                         'si' => __( 'Si', 'woocommerce' )
                     )
-                )
+                    ),
+                'tropipaydiscountpercent' => array(
+                    'title'       => __('Porciento de descuento que desea aplicar', 'woocomemerce'),
+                    'type'        => 'checkbox',
+                    'description' => __('Habilitar, si deseamos aplicar un descuento al pago del cliente <br> cuando utilice tropipay como método de pago'),
+                    'defult'      => 'no',
+                    'desc_tip'    => true,
+                    'class'       => 'tropipaycheckbox',
+                    'label'       => 'Activar descuento'     
+
+                ),
+                'tropipaydiscountpercentcuantity' => array(
+                    'title' => __('Valor del porciento de descuento','woocommerce'),
+                    'type'  => 'text',
+                    'description' => __('Valor del pociento de descueto que se desea aplicar a la cuenta del cliente. <br> Este porciento será aplicado al monto final de la cuenta del cliente.'),
+                    'default' => '0',
+                    'desc_tip' => true,
+                    'class' =>  "tropipayinput",
+                     ),
+                'tropipaydiscountamount' => array(
+                    'title'  => __('Aplicar valor fijo de descuento','woocommerce'),
+                    'type'   => 'checkbox',
+                    'description' => __('Habilitar si deseamos aplicar un descuento fijo a la cuenta del cliente <br> cuando utilice tropipay como método de pago'),
+                    'default' => 'no',
+                    'desc_tip' => true,
+                    'class' => 'tropipaycheckbox',
+                    'laber' => 'Activar descuento de valor fijo'
+                ),
+                'tropipaydiscountamountcuantity' => array(
+                    'title' => __('Valor fijo a descontar','woocommerce'),
+                    'type'  => 'text',
+                    'description' => __('Valor fijo que se desea descontar a la cuenta del cliente.'),
+                    'default' => '0',
+                    'desc_tip' => true,
+                    'class' =>  "tropipayinput",
+                     )
 			   	);
 				
 				$tmp_estados=wc_get_order_statuses();
@@ -293,6 +328,8 @@ class WC_Tropipay extends WC_Payment_Gateway {
 					$this->form_fields['tropipayestado']['options'][substr($est_id,3)]=$est_na;
 				}
     }
+
+   
 
     function process_payment( $order_id ) {
         global $woocommerce;

--- a/tropipay/wc-tropipay.php
+++ b/tropipay/wc-tropipay.php
@@ -1,36 +1,38 @@
 <?php
 
 /**
-* NOTA SOBRE LA LICENCIA DE USO DEL SOFTWARE
-* 
-* El uso de este software está sujeto a las Condiciones de uso de software que
-* se incluyen en el paquete en el documento "Aviso Legal.pdf". También puede
-* obtener una copia en la siguiente url:
-* https://www.tropipay.com/terms
-* 
-* Tropipay es titular de todos los derechos de propiedad intelectual e industrial
-* del software.
-* 
-* Quedan expresamente prohibidas la reproducción, la distribución y la
-* comunicación pública, incluida su modalidad de puesta a disposición con fines
-* distintos a los descritos en las Condiciones de uso.
-* 
-* Tropipay se reserva la posibilidad de ejercer las acciones legales que le
-* correspondan para hacer valer sus derechos frente a cualquier infracción de
-* los derechos de propiedad intelectual y/o industrial.
-* 
-* Tropipay
-*/
+ * NOTA SOBRE LA LICENCIA DE USO DEL SOFTWARE
+ * 
+ * El uso de este software está sujeto a las Condiciones de uso de software que
+ * se incluyen en el paquete en el documento "Aviso Legal.pdf". También puede
+ * obtener una copia en la siguiente url:
+ * https://www.tropipay.com/terms
+ * 
+ * Tropipay es titular de todos los derechos de propiedad intelectual e industrial
+ * del software.
+ * 
+ * Quedan expresamente prohibidas la reproducción, la distribución y la
+ * comunicación pública, incluida su modalidad de puesta a disposición con fines
+ * distintos a los descritos en las Condiciones de uso.
+ * 
+ * Tropipay se reserva la posibilidad de ejercer las acciones legales que le
+ * correspondan para hacer valer sus derechos frente a cualquier infracción de
+ * los derechos de propiedad intelectual y/o industrial.
+ * 
+ * Tropipay
+ */
 include __DIR__ . "/TppSDK/TropiPay.php";
 
-class WC_Tropipay extends WC_Payment_Gateway {
+class WC_Tropipay extends WC_Payment_Gateway
+{
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->id                 = 'tropipay';
         // $this->icon               = home_url() . '/wp-content/plugins/tropipay/pages/assets/images/logoTropiPayp2.png';
-        $this->method_title       = __( 'Pago con Tarjeta (Tropipay)', 'woocommerce' );
-        $this->method_description = __( 'Esta es la opción de la pasarela de pago de Tropipay.', 'woocommerce' );
-        $this ->notify_url        = add_query_arg( 'wc-api', 'WC_tropipay', home_url( '/' ) );
+        $this->method_title       = __('Pago con Tarjeta (Tropipay)', 'woocommerce');
+        $this->method_description = __('Esta es la opción de la pasarela de pago de Tropipay.', 'woocommerce');
+        $this->notify_url        = add_query_arg('wc-api', 'WC_tropipay', home_url('/'));
         $this->log                =  new WC_Logger();
         $this->idLog              = $this->generateIdLog();
 
@@ -41,37 +43,36 @@ class WC_Tropipay extends WC_Payment_Gateway {
         $this->init_form_fields();
         //$this->payment_fields();
 
-        $this->title              = $this->get_option( 'title' );
-        $this->description        = $this->get_option( 'description' );
-        
+        $this->title              = $this->get_option('title');
+        $this->description        = $this->get_option('description');
+
         // Get settings
-        $this->tropipayentorno            = $this->get_option( 'tropipayentorno' );
-        $this->tropipaymail             = $this->get_option( 'tropipaymail' );
-        $this->tropipaypassw                = $this->get_option( 'tropipaypassw' );
-        $this->tropipaymoneda             = $this->get_option( 'tropipaymoneda' );
-        $this->tropipayactivar_log	  = $this->get_option( 'tropipayactivar_log' );
-        $this->tropipayestado             = $this->get_option( 'tropipayestado' );
-        $this->tropipayaddFees                  = $this->get_option( 'tropipayaddFees');
+        $this->tropipayentorno            = $this->get_option('tropipayentorno');
+        $this->tropipaymail             = $this->get_option('tropipaymail');
+        $this->tropipaypassw                = $this->get_option('tropipaypassw');
+        $this->tropipaymoneda             = $this->get_option('tropipaymoneda');
+        $this->tropipayactivar_log      = $this->get_option('tropipayactivar_log');
+        $this->tropipayestado             = $this->get_option('tropipayestado');
+        $this->tropipayaddFees                  = $this->get_option('tropipayaddFees');
         $this->tropipayfeecardpercent = $this->get_option('tropipayfeecardpercent');
         $this->tropipayfeecardfixed = $this->get_option('tropipayfeecardfixed');
         $this->tropipayfeebalancepercent = $this->get_option('tropipayfeebalancepercent');
         $this->tropipayfeebalancefixed = $this->get_option('tropipayfeebalancefixed');
         $this->tropipayshowfees = $this->get_option('tropipayshowfees');
         $this->tropipayshowlogo = $this->get_option('tropipayshowlogo');
-        
+
 
 
         // Actions
-        add_action( 'woocommerce_receipt_tropipay', array( $this, 'receipt_page_tropipay' ) );
-        add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+        add_action('woocommerce_receipt_tropipay', array($this, 'receipt_page_tropipay'));
+        add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         //Payment listener/API hook
-        add_action( 'woocommerce_api_wc_tropipay', array( $this, 'check_rds_response' ) );
-        add_action( 'wp_enqueue_scripts', [ $this, 'payment_scripts' ] );
-
-        
+        add_action('woocommerce_api_wc_tropipay', array($this, 'check_rds_response'));
+        add_action('wp_enqueue_scripts', [$this, 'payment_scripts']);
     }
 
-    function generateIdLog() {
+    function generateIdLog()
+    {
         $vars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $stringLength = strlen($vars);
         $result = '';
@@ -81,9 +82,10 @@ class WC_Tropipay extends WC_Payment_Gateway {
         return $result;
     }
 
-    function payment_scripts() {
-        wp_register_style( 'tropipay_styles', plugins_url( 'pages/assets/css/tropipay.css', WC_TROPIPAY_MAIN_FILE ));
-		wp_enqueue_style( 'tropipay_styles' );
+    function payment_scripts()
+    {
+        wp_register_style('tropipay_styles', plugins_url('pages/assets/css/tropipay.css', WC_TROPIPAY_MAIN_FILE));
+        wp_enqueue_style('tropipay_styles');
     }
 
     /*function payment_fields() {
@@ -99,295 +101,275 @@ class WC_Tropipay extends WC_Payment_Gateway {
         echo '</div>';
     }*/
 
-      //Agregando los atributos requiere  a las opciones que asi lo necesitan
-      //y validaciones en la entrada
-      //Esto tengo que pasarlo despues para un doc aparte con todo el javascript
-    function add_attribs_script() {
-        ?>
-        <script>
-            /*document.addEventListener("DOMContentLoaded",function(){
+    //Agregando los atributos requiere  a las opciones que asi lo necesitan
+    //y validaciones en la entrada
+    //Esto tengo que pasarlo despues para un doc aparte con todo el javascript
 
-                var txtrequire=document.getElementsByClassName("tropipayinput");
-                    Array.prototype.forEach.call(txtrequire, function(txt) {
-                         txt.setAttribute("required", "");
-                         txt.addEventListener("input",()=>{
-                            if(!/^\d*$/.test(txt.value)){
-                                txt.value=txt.value.substring(0,txt.value.length-1);
-                            }
-                                                    
-                         });
-                });               
-                                            
-            });*/
-    
-        </script>
-      <?php
-      }
 
-    function init_form_fields() {
+    function init_form_fields()
+    {
         global $woocommerce;
 
         $this->form_fields = array(
-                'enabled' => array(
-                        'title'       => __( 'Activar Tropipay:', 'woocommerce' ),
-                        'label'       => __( 'Activar pago Tropipay', 'woocommerce' ),
-                        'type'        => 'checkbox',
-                        'description' => '',
-                        'default'     => 'yes'
-                ),
-                'title' => array(
-                        'title'       => __( 'Título', 'woocommerce' ),
-                        'type'        => 'text',
-                        'description' => __( 'Payment method description that the customer will see on your checkout.', 'woocommerce' ),
-                        'default'     => __( 'Pago con TropiPay', 'woocommerce' ),
-                        'desc_tip'    => true,
-                ),
-                'description' => array(
-                        'title'       => __( 'Descripción', 'woocommerce' ),
-                        'type'        => 'textarea',
-                        'description' => __( 'Payment method description that the customer will see on your website.', 'woocommerce' ),
-                        'default'     => __( 'Esta es la opción de la pasarela de pago con tarjeta de Tropipay. Te ayudamos en todo lo que necesites desde nuestra web: <b>www.tropipay.com</b>', 'woocommerce' ),
-                        'desc_tip'    => true,
-                ),
-                'tropipayentorno' => array(
-                        'title'       => __( 'Entorno de Tropipay', 'woocommerce' ),
-                        'type'        => 'select',
-                        'description' => __( 'Entorno del proceso de pago.', 'woocommerce' ),
-                        'default'     => 'Sandbox',
-                        'desc_tip'    => true,
-                        'options'     => array(
-                                'Sandbox' => __( 'Sandbox', 'woocommerce' ),
-                                'Live' => __( 'Live', 'woocommerce' )
-                        )
-                ),
-                'clientid' => array(
-                        'title'       => __( 'Client Id', 'woocommerce' ),
-                        'type'        => 'text',
-                        'description' => __( 'Client Id', 'woocommerce' ),
-                        'default'     => __( 'Client Id', 'woocommerce' ),
-                        'desc_tip'    => true,
-                ),
-                'clientsecret' => array(
-                        'title'       => __( 'Client Secret', 'woocommerce' ),
-                        'type'        => 'password',
-                        'description' => __( 'Client Secret.', 'woocommerce' ),
-                        'default'     => __( '', 'woocommerce' ),
-                        'desc_tip'    => true
-                ),
-                'tropipaymoneda' => array(
-                        'title'       => __( 'Tipo de Moneda', 'woocommerce' ),
-                        'type'        => 'select',
-                        'description' => __( 'Moneda del proceso de pago.', 'woocommerce' ),
-                        'default'     => 'AUTO',
-                        'desc_tip'    => true,
-                        'options'     => array(
-                                'AUTO' => __( 'AUTO', 'woocommerce' ),
-                                'EUR' => __( 'EURO', 'woocommerce' ),
-                                'USD' => __( 'DOLAR', 'woocommerce' )
-                        )
-                ),
-                'tropimethod' => array(
-                    'title'           => __( 'Método del formulario', 'woocommerce' ),
-                    'type'            => 'select',
-                    'description'     => __( 'Formulario embebido o redirección externa, para pagos con balance de TropiPay siempre será redirección', 'woocommerce'),
-                    'default'         => 'redirect',
-                    'desc_tip'        => true,
-                    'options'         => array(
-                        'redirect' => __('Redirección externa', 'woocommerce'),
-                        'embed' => __('Formulario embebido' , 'woocommerce')
-                    )
-                ),
-                'tropipaymentmethods' => array(
-                    'title'            => __( 'Formas de pago', 'woocommerce' ),
-                    'type'             => 'select',
-                    'description'      => __( 'Seleccione las formas de pago que desee', 'woocommerce'),
-                    'default'          => '',
-                    'desc_tip'         => true,
-                    'options'          => array(
-                        'normal' => __('Pagar con tarjeta y con saldo Tropipay', 'woocommerce'),
-                        'onlycard' => __('Solo Pagar con tarjeta', 'woocommerce'),
-                        'onlytpp' => __('Solo Pagar con Tropipay', 'woocommerce'),
-                    )
-                ),
-                'tropipayshowlogo' => array(
-                    'title'       => __( 'Mostrar logo de TropiPay', 'woocommerce' ),
-                    'type'        => 'select',
-                    'description' => __( '', 'woocommerce' ),
-                    'default'     => 'si',
-                    'desc_tip'    => true,
-                    'options'     => array(
-                            'no' => __( 'No', 'woocommerce' ),
-                            'si' => __( 'Si', 'woocommerce' )
-                    )
-                ),
-                'tropipayactivar_log' => array(
-                        'title'       => __( 'Activar Log', 'woocommerce' ),
-                        'type'        => 'select',
-                        'description' => __( 'Activar trazas de log.', 'woocommerce' ),
-                        'default'     => 'no',
-                        'desc_tip'    => true,
-                        'options'     => array(
-                                'no' => __( 'No', 'woocommerce' ),
-                                'si' => __( 'Si', 'woocommerce' )
-                        )
-                ),
-				'tropipayestado' => array(
-					'title'       => __( 'Estado', 'tropipay-woo' ),
-					'type'        => 'select',
-					'description' => __( 'Estado tras el pago.', 'tropipay-woo' ),
-					'default'     => 'no',
-					'desc_tip'    => true,
-					'options'     => array()
-				),
-                'tropiexpirationdays' => array(
-                    'title'           => __( 'Días de cancelación', 'tropipay-woo'),
-                    'type'            => 'select',
-                    'description'     => __( '', 'woocommerce'),
-                    'default'         => 0,
-                    'desc_tip'        => true,
-                    'options'         => array(
-                        0 => '0',
-                        1 => '1',
-                        2 => '2',
-                        3 => '3',
-                        4 => '4',
-                        5 => '5',
-                        6 => '6',
-                        7 => '7',
-                        8 => '8',
-                        9 => '9',
-                        10 => '10',
-                        15 => '15',
-                        20 => '20'
-                    )
-                ),
-				'tropipayaddFees' => array(
-					'title'       => __( 'Agregar Fees', 'tropipay-woo' ),
-					'type'        => 'select',
-					'description' => __( 'Agregar Fees.', 'tropipay-woo' ),
-					'default'     => 'no',
-					'desc_tip'    => true,
-                    'options'     => array(
-                        'no' => __( 'No', 'woocommerce' ),
-                        'si' => __( 'Si', 'woocommerce' )
-                    )
-                ),
-                'tropipayfeecardpercent' => array(
-                    'title'       => __( 'Fee de pago por tarjeta (%)', 'woocommerce' ),
-                    'type'        => 'text',
-                    'description' => __( 'Porcentaje fee para tarjeta (valor por defecto: 3.45)', 'woocommerce' ),
-                    'default'     => '3.45',
-                    'desc_tip'    => true,
-                ),
-                'tropipayfeecardfixed' => array(
-                    'title'       => __( 'Fee de pago por tarjeta (fijo)', 'woocommerce' ),
-                    'type'        => 'text',
-                    'description' => __( 'Fee fijo para tarjeta (valor por defecto: 0.5)', 'woocommerce' ),
-                    'default'     => '0.5',
-                    'desc_tip'    => true,
-                ),
-                'tropipayfeebalancepercent' => array(
-                    'title'       => __( 'Fee de pago con balance (%)', 'woocommerce' ),
-                    'type'        => 'text',
-                    'description' => __( 'Porcentaje fee para tarjeta (valor por defecto: 1.0)', 'woocommerce' ),
-                    'default'     => '1.0',
-                    'desc_tip'    => true,
-                ),
-                'tropipayfeebalancefixed' => array(
-                    'title'       => __( 'Fee de pago con balance (fijo)', 'woocommerce' ),
-                    'type'        => 'text',
-                    'description' => __( 'Fee fijo para balance (valor por defecto: 0)', 'woocommerce' ),
-                    'default'     => '0',
-                    'desc_tip'    => true,
-                ),
-				'tropipayshowfees' => array(
-					'title'       => __( 'Mostrar fees', 'tropipay-woo' ),
-					'type'        => 'select',
-					'description' => __( 'Mostrar Fees.', 'tropipay-woo' ),
-					'default'     => 'no',
-					'desc_tip'    => true,
-                    'options'     => array(
-                        'no' => __( 'No', 'woocommerce' ),
-                        'si' => __( 'Si', 'woocommerce' )
-                    )
-                    ),
-                'tropipaydiscountpercent' => array(
-                    'title'       => __('Porciento de descuento que desea aplicar', 'woocomemerce'),
-                    'type'        => 'checkbox',
-                    'description' => __('Habilitar, si deseamos aplicar un descuento al pago del cliente <br> cuando utilice tropipay como método de pago'),
-                    'defult'      => 'no',
-                    'desc_tip'    => true,
-                    'class'       => 'tropipaycheckbox',
-                    'label'       => 'Activar descuento'     
+            'enabled' => array(
+                'title'       => __('Activar Tropipay:', 'woocommerce'),
+                'label'       => __('Activar pago Tropipay', 'woocommerce'),
+                'type'        => 'checkbox',
+                'description' => '',
+                'default'     => 'yes'
+            ),
+            'title' => array(
+                'title'       => __('Título', 'woocommerce'),
+                'type'        => 'text',
+                'description' => __('Payment method description that the customer will see on your checkout.', 'woocommerce'),
+                'default'     => __('Pago con TropiPay', 'woocommerce'),
+                'desc_tip'    => true,
+            ),
+            'description' => array(
+                'title'       => __('Descripción', 'woocommerce'),
+                'type'        => 'textarea',
+                'description' => __('Payment method description that the customer will see on your website.', 'woocommerce'),
+                'default'     => __('Esta es la opción de la pasarela de pago con tarjeta de Tropipay. Te ayudamos en todo lo que necesites desde nuestra web: <b>www.tropipay.com</b>', 'woocommerce'),
+                'desc_tip'    => true,
+            ),
+            'tropipayentorno' => array(
+                'title'       => __('Entorno de Tropipay', 'woocommerce'),
+                'type'        => 'select',
+                'description' => __('Entorno del proceso de pago.', 'woocommerce'),
+                'default'     => 'Sandbox',
+                'desc_tip'    => true,
+                'options'     => array(
+                    'Sandbox' => __('Sandbox', 'woocommerce'),
+                    'Live' => __('Live', 'woocommerce')
+                )
+            ),
+            'clientid' => array(
+                'title'       => __('Client Id', 'woocommerce'),
+                'type'        => 'text',
+                'description' => __('Client Id', 'woocommerce'),
+                'default'     => __('Client Id', 'woocommerce'),
+                'desc_tip'    => true,
+            ),
+            'clientsecret' => array(
+                'title'       => __('Client Secret', 'woocommerce'),
+                'type'        => 'password',
+                'description' => __('Client Secret.', 'woocommerce'),
+                'default'     => __('', 'woocommerce'),
+                'desc_tip'    => true
+            ),
+            'tropipaymoneda' => array(
+                'title'       => __('Tipo de Moneda', 'woocommerce'),
+                'type'        => 'select',
+                'description' => __('Moneda del proceso de pago.', 'woocommerce'),
+                'default'     => 'AUTO',
+                'desc_tip'    => true,
+                'options'     => array(
+                    'AUTO' => __('AUTO', 'woocommerce'),
+                    'EUR' => __('EURO', 'woocommerce'),
+                    'USD' => __('DOLAR', 'woocommerce')
+                )
+            ),
+            'tropimethod' => array(
+                'title'           => __('Método del formulario', 'woocommerce'),
+                'type'            => 'select',
+                'description'     => __('Formulario embebido o redirección externa, para pagos con balance de TropiPay siempre será redirección', 'woocommerce'),
+                'default'         => 'redirect',
+                'desc_tip'        => true,
+                'options'         => array(
+                    'redirect' => __('Redirección externa', 'woocommerce'),
+                    'embed' => __('Formulario embebido', 'woocommerce')
+                )
+            ),
+            'tropipaymentmethods' => array(
+                'title'            => __('Formas de pago', 'woocommerce'),
+                'type'             => 'select',
+                'description'      => __('Seleccione las formas de pago que desee', 'woocommerce'),
+                'default'          => '',
+                'desc_tip'         => true,
+                'options'          => array(
+                    'normal' => __('Pagar con tarjeta y con saldo Tropipay', 'woocommerce'),
+                    'onlycard' => __('Solo Pagar con tarjeta', 'woocommerce'),
+                    'onlytpp' => __('Solo Pagar con Tropipay', 'woocommerce'),
+                )
+            ),
+            'tropipayshowlogo' => array(
+                'title'       => __('Mostrar logo de TropiPay', 'woocommerce'),
+                'type'        => 'select',
+                'description' => __('', 'woocommerce'),
+                'default'     => 'si',
+                'desc_tip'    => true,
+                'options'     => array(
+                    'no' => __('No', 'woocommerce'),
+                    'si' => __('Si', 'woocommerce')
+                )
+            ),
+            'tropipayactivar_log' => array(
+                'title'       => __('Activar Log', 'woocommerce'),
+                'type'        => 'select',
+                'description' => __('Activar trazas de log.', 'woocommerce'),
+                'default'     => 'no',
+                'desc_tip'    => true,
+                'options'     => array(
+                    'no' => __('No', 'woocommerce'),
+                    'si' => __('Si', 'woocommerce')
+                )
+            ),
+            'tropipayestado' => array(
+                'title'       => __('Estado', 'tropipay-woo'),
+                'type'        => 'select',
+                'description' => __('Estado tras el pago.', 'tropipay-woo'),
+                'default'     => 'no',
+                'desc_tip'    => true,
+                'options'     => array()
+            ),
+            'tropiexpirationdays' => array(
+                'title'           => __('Días de cancelación', 'tropipay-woo'),
+                'type'            => 'select',
+                'description'     => __('', 'woocommerce'),
+                'default'         => 0,
+                'desc_tip'        => true,
+                'options'         => array(
+                    0 => '0',
+                    1 => '1',
+                    2 => '2',
+                    3 => '3',
+                    4 => '4',
+                    5 => '5',
+                    6 => '6',
+                    7 => '7',
+                    8 => '8',
+                    9 => '9',
+                    10 => '10',
+                    15 => '15',
+                    20 => '20'
+                )
+            ),
+            'tropipayaddFees' => array(
+                'title'       => __('Agregar Fees', 'tropipay-woo'),
+                'type'        => 'select',
+                'description' => __('Agregar Fees.', 'tropipay-woo'),
+                'default'     => 'no',
+                'desc_tip'    => true,
+                'options'     => array(
+                    'no' => __('No', 'woocommerce'),
+                    'si' => __('Si', 'woocommerce')
+                )
+            ),
+            'tropipayfeecardpercent' => array(
+                'title'       => __('Fee de pago por tarjeta (%)', 'woocommerce'),
+                'type'        => 'text',
+                'description' => __('Porcentaje fee para tarjeta (valor por defecto: 3.45)', 'woocommerce'),
+                'default'     => '3.45',
+                'desc_tip'    => true,
+            ),
+            'tropipayfeecardfixed' => array(
+                'title'       => __('Fee de pago por tarjeta (fijo)', 'woocommerce'),
+                'type'        => 'text',
+                'description' => __('Fee fijo para tarjeta (valor por defecto: 0.5)', 'woocommerce'),
+                'default'     => '0.5',
+                'desc_tip'    => true,
+            ),
+            'tropipayfeebalancepercent' => array(
+                'title'       => __('Fee de pago con balance (%)', 'woocommerce'),
+                'type'        => 'text',
+                'description' => __('Porcentaje fee para tarjeta (valor por defecto: 1.0)', 'woocommerce'),
+                'default'     => '1.0',
+                'desc_tip'    => true,
+            ),
+            'tropipayfeebalancefixed' => array(
+                'title'       => __('Fee de pago con balance (fijo)', 'woocommerce'),
+                'type'        => 'text',
+                'description' => __('Fee fijo para balance (valor por defecto: 0)', 'woocommerce'),
+                'default'     => '0',
+                'desc_tip'    => true,
+            ),
+            'tropipayshowfees' => array(
+                'title'       => __('Mostrar fees', 'tropipay-woo'),
+                'type'        => 'select',
+                'description' => __('Mostrar Fees.', 'tropipay-woo'),
+                'default'     => 'no',
+                'desc_tip'    => true,
+                'options'     => array(
+                    'no' => __('No', 'woocommerce'),
+                    'si' => __('Si', 'woocommerce')
+                )
+            ),
+            'tropipaydiscountpercent' => array(
+                'title'       => __('Porciento de descuento que desea aplicar', 'woocomemerce'),
+                'type'        => 'checkbox',
+                'description' => __('Habilitar, si deseamos aplicar un descuento al pago del cliente <br> cuando utilice tropipay como método de pago'),
+                'defult'      => 'no',
+                'desc_tip'    => true,
+                'class'       => 'tropipaycheckbox',
+                'label'       => 'Activar descuento'
 
-                ),
-                'tropipaydiscountpercentcuantity' => array(
-                    'title' => __('Valor del porciento de descuento','woocommerce'),
-                    'type'  => 'text',
-                    'description' => __('Valor del pociento de descueto que se desea aplicar a la cuenta del cliente. <br> Este porciento será aplicado al monto final de la cuenta del cliente.'),
-                    'default' => 0,
-                    'desc_tip' => true,
-                    'class' =>  "tropipayinput",
-                     ),
-                'tropipaydiscountamount' => array(
-                    'title'  => __('Aplicar valor fijo de descuento','woocommerce'),
-                    'type'   => 'checkbox',
-                    'description' => __('Habilitar si deseamos aplicar un descuento fijo a la cuenta del cliente <br> cuando utilice tropipay como método de pago'),
-                    'default' => 'no',
-                    'desc_tip' => true,
-                    'class' => 'tropipaycheckbox',
-                    'laber' => 'Activar descuento de valor fijo'
-                ),
-                'tropipaydiscountamountcuantity' => array(
-                    'title' => __('Valor fijo a descontar','woocommerce'),
-                    'type'  => 'text',
-                    'description' => __('Valor fijo que se desea descontar a la cuenta del cliente.'),
-                    'default' => 0,
-                    'desc_tip' => true,
-                    'class' =>  "tropipayinput",
-                    )
-			   	);
+            ),
+            'tropipaydiscountpercentcuantity' => array(
+                'title' => __('Valor del porciento de descuento', 'woocommerce'),
+                'type'  => 'text',
+                'description' => __('Valor del pociento de descueto que se desea aplicar a la cuenta del cliente. <br> Este porciento será aplicado al monto final de la cuenta del cliente.'),
+                'default' => 0,
+                'desc_tip' => true,
+                'class' =>  "tropipayinput",
+            ),
+            'tropipaydiscountamount' => array(
+                'title'  => __('Aplicar valor fijo de descuento', 'woocommerce'),
+                'type'   => 'checkbox',
+                'description' => __('Habilitar si deseamos aplicar un descuento fijo a la cuenta del cliente <br> cuando utilice tropipay como método de pago'),
+                'default' => 'no',
+                'desc_tip' => true,
+                'class' => 'tropipaycheckbox',
+                'laber' => 'Activar descuento de valor fijo'
+            ),
+            'tropipaydiscountamountcuantity' => array(
+                'title' => __('Valor fijo a descontar', 'woocommerce'),
+                'type'  => 'text',
+                'description' => __('Valor fijo que se desea descontar a la cuenta del cliente.'),
+                'default' => 0,
+                'desc_tip' => true,
+                'class' =>  "tropipayinput",
+            )
+        );
 
-                //Agregando los atributos a los campos requieridos
-                //$this->add_attribs_script();
-                
-				
-				$tmp_estados=wc_get_order_statuses();
 
-               	foreach($tmp_estados as $est_id=>$est_na){
-                    $this->form_fields['tropipayestado']['options'][substr($est_id,3)]=$est_na;
-				}
-    
-            }
-    function process_payment( $order_id ) {
+
+        $tmp_estados = wc_get_order_statuses();
+
+        foreach ($tmp_estados as $est_id => $est_na) {
+            $this->form_fields['tropipayestado']['options'][substr($est_id, 3)] = $est_na;
+        }
+    }
+    function process_payment($order_id)
+    {
         global $woocommerce;
         $order = new WC_Order($order_id);
-        $logActivo=$this->tropipayactivar_log;
-        $this->tropipayescribirLog_wc($this->idLog." -- "."Acceso a la opción de pago con tarjeta de Tropipay",$logActivo);
+        $logActivo = $this->tropipayactivar_log;
+        $this->tropipayescribirLog_wc($this->idLog . " -- " . "Acceso a la opción de pago con tarjeta de Tropipay", $logActivo);
         // Return receipt_page redirect
         return array(
-            'result' 	=> 'success',
-            'redirect'	=> $order->get_checkout_payment_url( true )
+            'result'     => 'success',
+            'redirect'    => $order->get_checkout_payment_url(true)
         );
     }
 
-    function generate_tropipay_form( $order_id ) {
-            // Version
+    function generate_tropipay_form($order_id)
+    {
+        // Version
         $merchantModule = 'woocommerce_tropipay_1.0.0';
 
         //Recuperamos los datos de config.
-        $logActivo=$this->get_option('tropipayactivar_log');
-        $clientid=$this->get_option('clientid');
-        $clientsecret=$this->get_option('clientsecret');
-        $monedaconf=$this->get_option('tropipaymoneda');
-        $entorno=$this->get_option('tropipayentorno');
-        $tropimethod=$this->get_option('tropimethod');
-        $tropipaymentmethods=$this->get_option('tropipaymentmethods');
+        $logActivo = $this->get_option('tropipayactivar_log');
+        $clientid = $this->get_option('clientid');
+        $clientsecret = $this->get_option('clientsecret');
+        $monedaconf = $this->get_option('tropipaymoneda');
+        $entorno = $this->get_option('tropipayentorno');
+        $tropimethod = $this->get_option('tropimethod');
+        $tropipaymentmethods = $this->get_option('tropipaymentmethods');
 
-        $this->tropipayescribirLog_wc($this->idLog." -- "."Acceso al formulario de pago con tarjeta de Tropipay",$logActivo);
+        $this->tropipayescribirLog_wc($this->idLog . " -- " . "Acceso al formulario de pago con tarjeta de Tropipay", $logActivo);
 
         //Callback
-        $urltienda = $this -> notify_url;
+        $urltienda = $this->notify_url;
 
         //Objeto tipo pedido
         $order = new WC_Order($order_id);
@@ -398,50 +380,48 @@ class WC_Tropipay extends WC_Payment_Gateway {
         $transaction_amount = floatval($transaction_amount);*/
         $transaction_amount = (int) str_replace(',', '', number_format($order->get_total() * 100, 2));
 
-        if($monedaconf === 'AUTO') {
+        if ($monedaconf === 'AUTO') {
             $moneda = $order->get_currency();
         } else {
             $moneda = $monedaconf;
         }
 
 
-        $numpedido =  str_pad($order_id, 8, "0", STR_PAD_LEFT).date('is');
+        $numpedido =  str_pad($order_id, 8, "0", STR_PAD_LEFT) . date('is');
 
         //Se establece el entorno del SIS
-        if($entorno=="Sandbox"){
-            $tropipay_server="https://tropipay-dev.herokuapp.com";
-            $environment="develop";
-        }
-        else if($entorno=="Live"){
-            $tropipay_server="https://www.tropipay.com";
-            $environment="production";
+        if ($entorno == "Sandbox") {
+            $tropipay_server = "https://tropipay-dev.herokuapp.com";
+            $environment = "develop";
+        } else if ($entorno == "Live") {
+            $tropipay_server = "https://www.tropipay.com";
+            $environment = "production";
         }
 
         $srv = new TropiPay($clientid, $clientsecret, $environment);
 
         $datetime = new DateTime('today');
-        $arraycliente["name"]=$order->get_billing_first_name();
-        $arraycliente["lastName"]=$order->get_billing_last_name();
-        $arraycliente["address"]=$order->get_billing_address_1() . ", " . $order->get_billing_city() . ", " . $order->get_billing_postcode();
-        if($order->get_billing_phone()) {
-            $arraycliente["phone"]=$order->get_billing_phone();
+        $arraycliente["name"] = $order->get_billing_first_name();
+        $arraycliente["lastName"] = $order->get_billing_last_name();
+        $arraycliente["address"] = $order->get_billing_address_1() . ", " . $order->get_billing_city() . ", " . $order->get_billing_postcode();
+        if ($order->get_billing_phone()) {
+            $arraycliente["phone"] = $order->get_billing_phone();
+        } else {
+            $arraycliente["phone"] = $order->get_shipping_phone();
         }
-         else {
-            $arraycliente["phone"]=$order->get_shipping_phone();
-        }
-        $arraycliente["email"]=$order->get_billing_email();
+        $arraycliente["email"] = $order->get_billing_email();
         //$arraycliente["countryId"] = 1;
         $arraycliente["countryIso"] = $order->get_billing_country();
-        if(strlen($arraycliente["countryIso"])==0) {
+        if (strlen($arraycliente["countryIso"]) == 0) {
             $arraycliente["countryId"] = 1;
-            unset( $arraycliente["countryIso"] );
+            unset($arraycliente["countryIso"]);
         }
         $arraycliente["termsAndConditions"] = true;
-        $arraycliente["state"]=$order->get_billing_state();
-        $arraycliente["city"]=$order->get_billing_city();
-        $arraycliente["postCode"]=$order->get_billing_postcode();
+        $arraycliente["state"] = $order->get_billing_state();
+        $arraycliente["city"] = $order->get_billing_city();
+        $arraycliente["postCode"] = $order->get_billing_postcode();
         //$moneda=$this->get_option('tropipaymoneda');
-        $datos=array(
+        $datos = array(
             "reference" => $numpedido,
             "concept" => __('Order #: ') . $order->get_id(),
             "description" => " ",
@@ -460,57 +440,56 @@ class WC_Tropipay extends WC_Payment_Gateway {
             "favorite" => false,
             "paymentMethods"
         );
-        $selectedMethod = get_post_meta( $order_id, 'tropipay_payment_method', true );
-        switch($selectedMethod) {
+        $selectedMethod = get_post_meta($order_id, 'tropipay_payment_method', true);
+        switch ($selectedMethod) {
             case 'card':
-                $datos["paymentMethods"]=array("EXT");
+                $datos["paymentMethods"] = array("EXT");
                 break;
             case 'balance':
-                $datos["paymentMethods"]=array("TPP");
+                $datos["paymentMethods"] = array("TPP");
                 break;
         }
         $paylink = $srv->createPaylink($datos);
-        //var_dump($datos);
-        $shorturl=$paylink['data']['shortUrl'];
-        
-        $paymenturl=$paylink['data']['paymentUrl'];
+        $shorturl = $paylink['data']['shortUrl'];
+
+        $paymenturl = $paylink['data']['paymentUrl'];
 
         //$paymenturl=$paylink['data']['rawUrlPayment'];
 
         $action = $shorturl;
 
 
-        if($tropimethod==="embed" && $selectedMethod==='card') {
-            return '<iframe style="border:none;width:100%;height:500px;" src="' . $paymenturl  .'"></iframe> <a class="button cancel" href="'.$order->get_cancel_order_url().'">'.__('Cancelar Pedido', 'tropipay').'</a>';
-        }
-        else {
-            return '<h4>Espere, por favor</h4><form action="'.$action.'" method="GET" id="tropipay_payment_form" style="display:none;">'.
-                        '<input type="submit" class="button-alt" id="submit_tropipay_payment_form" value="'.__('Pagar con Tropipay', 'tropipay').'" />'.
-                        '<a class="button cancel" href="'.$order->get_cancel_order_url().'">'.__('Cancelar Pedido', 'tropipay').'</a>
+        if ($tropimethod === "embed" && $selectedMethod === 'card') {
+            return '<iframe style="border:none;width:100%;height:500px;" src="' . $paymenturl  . '"></iframe> <a class="button cancel" href="' . $order->get_cancel_order_url() . '">' . __('Cancelar Pedido', 'tropipay') . '</a>';
+        } else {
+            return '<h4>Espere, por favor</h4><form action="' . $action . '" method="GET" id="tropipay_payment_form" style="display:none;">' .
+                '<input type="submit" class="button-alt" id="submit_tropipay_payment_form" value="' . __('Pagar con Tropipay', 'tropipay') . '" />' .
+                '<a class="button cancel" href="' . $order->get_cancel_order_url() . '">' . __('Cancelar Pedido', 'tropipay') . '</a>
                     </form><script>document.getElementById("tropipay_payment_form").submit();</script>';
         }
-        
     }
 
-    function tropipay_payments_get_order_id($num) {
-      return intval(substr($num,0,-4));
+    function tropipay_payments_get_order_id($num)
+    {
+        return intval(substr($num, 0, -4));
     }
 
-    //Verificar respuesta del servidor para evitar suplantacion
-    function check_rds_response() {
+    /*Verificar respuesta del servidor para evitar suplantacion*/
+    function check_rds_response()
+    {
         $this->idLog = $this->generateIdLog();
-        $logActivo=$this->tropipayactivar_log;
-		$estado=$this->tropipayestado;
+        $logActivo = $this->tropipayactivar_log;
+        $estado = $this->tropipayestado;
 
-        $responsej=file_get_contents('php://input');
-        $response=json_decode($responsej,true);
+        $responsej = file_get_contents('php://input');
+        $response = json_decode($responsej, true);
         $ds_amount = $response["data"]["amount"];
         $ds_order = $response["data"]["reference"];
         $ds_bankordercode = $response["data"]["bankOrderCode"];
         $ds_amount = $response["data"]["originalCurrencyAmount"];
         $ds_merchant_clientid = $this->get_option('clientid');
         $ds_merchant_clientsecret = $this->get_option('clientsecret');
-        $ds_reference=$response["data"]["reference"];
+        $ds_reference = $response["data"]["reference"];
         $ds_currency = $response["data"]["currency"];
 
         $order_id = $this->tropipay_payments_get_order_id($ds_reference);
@@ -518,85 +497,83 @@ class WC_Tropipay extends WC_Payment_Gateway {
         //Se verifica el id de la orden que viene en la respues
         if ($order_id) {
             $order = new WC_Order($order_id);
-        }
-        else {
-            $this->tropipayescribirLog_wc($this->idLog." -- "."No se ha encontrado el pedido",$logActivo);
-            wp_die( '<img src="'.home_url().'/wp-content/plugins/tropipay/pages/assets/images/cross.png" alt="Desactivado" title="Desactivado" />
-            Fallo en el proceso de pago.<br>Su pedido ha sido cancelado.' );
+        } else {
+            $this->tropipayescribirLog_wc($this->idLog . " -- " . "No se ha encontrado el pedido", $logActivo);
+            wp_die('<img src="' . home_url() . '/wp-content/plugins/tropipay/pages/assets/images/cross.png" alt="Desactivado" title="Desactivado" />
+            Fallo en el proceso de pago.<br>Su pedido ha sido cancelado.');
             return;
         }
 
         //Se verifica que coincidan las cantidades a pagar
         $transaction_amount = (int) str_replace(',', '', number_format($order->get_total() * 100, 2));
-        if($transaction_amount != abs($ds_amount)) {
-            $this->tropipayescribirLog_wc($this->idLog." -- "."No coincide el amount",$logActivo);
-            wp_die( '<img src="'.home_url().'/wp-content/plugins/tropipay/pages/assets/images/cross.png" alt="Desactivado" title="Desactivado" />
-            Fallo en el proceso de pago.<br>Su pedido ha sido cancelado.' );
+        if ($transaction_amount != abs($ds_amount)) {
+            $this->tropipayescribirLog_wc($this->idLog . " -- " . "No coincide el amount", $logActivo);
+            wp_die('<img src="' . home_url() . '/wp-content/plugins/tropipay/pages/assets/images/cross.png" alt="Desactivado" title="Desactivado" />
+            Fallo en el proceso de pago.<br>Su pedido ha sido cancelado.');
             return;
         }
 
         //Validacion de firmas y registro del log para evidencia
         $firma_remota = $response["data"]["signaturev2"];
-        $firma_local=hash('sha256', $ds_bankordercode . $ds_merchant_clientid . $ds_merchant_clientsecret . $ds_amount);
-        $this->tropipayescribirLog_wc($this->idLog." -- "."firma remota: " .$firma_remota ,$logActivo);
-        $this->tropipayescribirLog_wc($this->idLog." -- "."firma local: " .$firma_local ,$logActivo);
-        $this->tropipayescribirLog_wc($this->idLog." -- "."response: " .$responsej ,$logActivo);
-        
-        if($firma_local==$firma_remota) {  
-            if($response["status"]=="OK") {
-                $order->update_status($estado,__( 'Awaiting Tropipay payment', 'woocommerce' ));
-                $this->tropipayescribirLog_wc($this->idLog." -- "."Operación finalizada. Respuesta del tpv: OK. PEDIDO ACEPTADO",$logActivo);
-                $order->reduce_order_stock();//Verificar si se puede actualizar esto a la par del estado
-                add_post_meta( $order_id, 'reference', $ds_order );
-                add_post_meta( $order_id, 'bankOrderCode', $ds_bankordercode );
+        $firma_local = hash('sha256', $ds_bankordercode . $ds_merchant_clientid . $ds_merchant_clientsecret . $ds_amount);
+        $this->tropipayescribirLog_wc($this->idLog . " -- " . "firma remota: " . $firma_remota, $logActivo);
+        $this->tropipayescribirLog_wc($this->idLog . " -- " . "firma local: " . $firma_local, $logActivo);
+        $this->tropipayescribirLog_wc($this->idLog . " -- " . "response: " . $responsej, $logActivo);
+
+        if ($firma_local == $firma_remota) {
+            if ($response["status"] == "OK") {
+                $order->update_status($estado, __('Awaiting Tropipay payment', 'woocommerce'));
+                $this->tropipayescribirLog_wc($this->idLog . " -- " . "Operación finalizada. Respuesta del tpv: OK. PEDIDO ACEPTADO", $logActivo);
+                $order->reduce_order_stock(); //Verificar si se puede actualizar esto a la par del estado
+                add_post_meta($order_id, 'reference', $ds_order);
+                add_post_meta($order_id, 'bankOrderCode', $ds_bankordercode);
                 // Remove cart
                 WC()->cart->empty_cart();
-            }
-            else {
+            } else {
                 //$order->update_status('cancelled',__( 'Awaiting Tropipay payment', 'woocommerce' ));
                 //WC()->cart->empty_cart();
-                $this->tropipayescribirLog_wc($this->idLog." -- "."Operación finalizada. Respuesta del tpv: KO. PEDIDO CANCELADO",$logActivo);
+                $this->tropipayescribirLog_wc($this->idLog . " -- " . "Operación finalizada. Respuesta del tpv: KO. PEDIDO CANCELADO", $logActivo);
             }
-        }
-        else {
-            $this->tropipayescribirLog_wc($this->idLog." -- "."No coinciden las firmas",$logActivo);
-            wp_die( '<img src="'.home_url().'/wp-content/plugins/tropipay/pages/assets/images/cross.png" alt="Desactivado" title="Desactivado" />
-                Fallo en el proceso de pago.<br>Su pedido ha sido cancelado.' );
+        } else {
+            $this->tropipayescribirLog_wc($this->idLog . " -- " . "No coinciden las firmas", $logActivo);
+            wp_die('<img src="' . home_url() . '/wp-content/plugins/tropipay/pages/assets/images/cross.png" alt="Desactivado" title="Desactivado" />
+                Fallo en el proceso de pago.<br>Su pedido ha sido cancelado.');
         }
     }
 
-    function receipt_page_tropipay( $order ) {
-        if( get_post_meta( $order, 'tropipay_payment_receipt', true ) ) 
+    function receipt_page_tropipay($order)
+    {
+        if (get_post_meta($order, 'tropipay_payment_receipt', true))
             return; // Exit if already processed
-        add_post_meta( $order, 'tropipay_payment_receipt', 'si' );
-        $logActivo=$this->tropipayactivar_log;
-        $this->tropipayescribirLog_wc($this->idLog." -- "."Acceso a la página de confirmación de la opción de pago con tarjeta de Tropipay",$logActivo);
-        
-        $selectedMethod = get_post_meta( $order, 'tropipay_payment_method', true );
-        
-        if($this->get_option('tropimethod')!='embed' || $selectedMethod === 'balance') {
-            echo '<p>'.__('Gracias por su pedido, por favor espera mientras le redireccionamos a la plataforma de pago. <img src="'.home_url().'/wp-content/plugins/tropipay/pages/assets/images/loading.gif" alt="Desactivado" title="Desactivado" />', 'tropipay-woo').'</p>';
-        }
-        else {
-            if($selectedMethod) {
-                echo '<p>'.__('Gracias por su pedido, por favor introduzca los datos de su Tarjeta.', 'tropipay-woo').'</p>';
+        add_post_meta($order, 'tropipay_payment_receipt', 'si');
+        $logActivo = $this->tropipayactivar_log;
+        $this->tropipayescribirLog_wc($this->idLog . " -- " . "Acceso a la página de confirmación de la opción de pago con tarjeta de Tropipay", $logActivo);
+
+        $selectedMethod = get_post_meta($order, 'tropipay_payment_method', true);
+
+        if ($this->get_option('tropimethod') != 'embed' || $selectedMethod === 'balance') {
+            echo '<p>' . __('Gracias por su pedido, por favor espera mientras le redireccionamos a la plataforma de pago. <img src="' . home_url() . '/wp-content/plugins/tropipay/pages/assets/images/loading.gif" alt="Desactivado" title="Desactivado" />', 'tropipay-woo') . '</p>';
+        } else {
+            if ($selectedMethod) {
+                echo '<p>' . __('Gracias por su pedido, por favor introduzca los datos de su Tarjeta.', 'tropipay-woo') . '</p>';
             }
         }
-        if($selectedMethod) {
-            echo $this -> generate_tropipay_form($order);
+        if ($selectedMethod) {
+            echo $this->generate_tropipay_form($order);
         }
-        
     }
 
-    function tropipayescribirLog_wc($texto,$activo) {
-        if($activo=="si"){
+    function tropipayescribirLog_wc($texto, $activo)
+    {
+        if ($activo == "si") {
             // Log
-            $this->log->add( 'tropipay', $texto."\r\n");
+            $this->log->add('tropipay', $texto . "\r\n");
         }
     }
 
 
-    function tropipay_get_bankordercode($order_id) {
-        return get_post_meta( $order_id, 'bankOrderCode', true );
+    function tropipay_get_bankordercode($order_id)
+    {
+        return get_post_meta($order_id, 'bankOrderCode', true);
     }
 }

--- a/tropipay/wc-tropipay.php
+++ b/tropipay/wc-tropipay.php
@@ -332,7 +332,7 @@ class WC_Tropipay extends WC_Payment_Gateway
                 'class' =>  "tropipayinput",
             ),
             'tropipaydiscountamount' => array(
-                'title'  => __('Aplicar valor fijo de descuento', 'woocommerce'),
+                'title'  => __('Activar valor fijo de descuento', 'woocommerce'),
                 'type'   => 'checkbox',
                 'description' => __('Habilitar si deseamos aplicar un descuento fijo a la cuenta del cliente <br> cuando utilice tropipay como método de pago'),
                 'default' => 'no',


### PR DESCRIPTION
### Lo nuevo

Agregado opciones en la configuración para para que se pueda aplicar cupones de descuento por el uso del método de pago y así incentivar en los clientes su uso.

En la Configuración:
![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/61018642-2d9f-4c13-90fd-a8a295bb9c95)

En el carrito:
![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/a6141357-1e58-43c0-b038-24011a0ceebc)
**Agregados los cupones de descuento**
![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/6fbe7746-17c2-4de8-aebf-eeee819552aa)
**Cuando esta seleccionada otra opción**
![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/5b6ca0fe-734c-48d0-8212-a562afb4170b)
Incluso cuando esta seleccionada otro método de pago pero estén activos los descuento se le notifica al cliente para incentivar el uso de este método de pago

### El Fix

Cuando cambiabas de método de pago despues de haber seleccionado el de tropipay, no se eliminaban los fee

Antes:
![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/f4cc9da9-5683-412e-9994-0deb5cefbd9b)
Método de pago seleccionado y fee aplicado

![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/cd2429bb-cb7b-4be5-a5d0-ea0f815a5bb3)
Cambio el método de pago y se mantiene el fee

![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/99a22123-af34-4a7c-8b31-156704371d80)
Incluso se procesa el pedido con el fee aplicado, que no sería la intención ni del cliente ni del usuario

Ahora:
![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/b00700f8-ec45-462f-af01-9faa510f37cb)
Tropipay seleccionado

![image](https://github.com/tropipay/woocomerce-tropipay-plugin/assets/118454215/4c3457f4-6b59-43b1-927c-3be7bac49ef9)
Cambio de método de pago




